### PR TITLE
Fixed exception on ExecuteAsync with GET request

### DIFF
--- a/PagarMe.Shared/PagarMeRequest.cs
+++ b/PagarMe.Shared/PagarMeRequest.cs
@@ -136,7 +136,7 @@ namespace PagarMe
             var request = GetRequest();
             bool isError = false;
 
-            if (Body != null)
+            if (Body != null && (Method == "POST" || Method == "PUT"))
             {
                 var encoding = new UTF8Encoding(false);
 


### PR DESCRIPTION
Added validation to not write body to a GET request. GET requests don't usually have bodies.