### PR TITLE
Serialize PaymentMethods

### DIFF
--- a/PagarMe.Shared/Plan.cs
+++ b/PagarMe.Shared/Plan.cs
@@ -24,6 +24,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using System.Linq;
+using PagarMe.Base;
 
 namespace PagarMe
 {
@@ -57,8 +59,19 @@ namespace PagarMe
 
         public PaymentMethod[] PaymentMethods
         {
-            get { return GetAttribute<PaymentMethod[]>("payment_methods"); }
-            set { SetAttribute("payment_methods", value); }
+            get
+			{
+				return GetAttribute<String[]> ("payment_methods")
+					.Select(s => EnumMagic.ConvertFromString(typeof(PaymentMethod), s))
+					.Cast<PaymentMethod>()
+					.ToArray();
+			}
+
+            set
+			{
+				var strings = value.Select(e => EnumMagic.ConvertToString(e)).ToArray();
+				SetAttribute("payment_methods", strings);
+			}
         }
 
         public string Color

--- a/PagarMe.Shared/Plan.cs
+++ b/PagarMe.Shared/Plan.cs
@@ -60,18 +60,18 @@ namespace PagarMe
         public PaymentMethod[] PaymentMethods
         {
             get
-			{
-				return GetAttribute<String[]> ("payment_methods")
-					.Select(s => EnumMagic.ConvertFromString(typeof(PaymentMethod), s))
-					.Cast<PaymentMethod>()
-					.ToArray();
-			}
+            {
+                return GetAttribute<String[]> ("payment_methods")
+                    .Select(s => EnumMagic.ConvertFromString(typeof(PaymentMethod), s))
+                    .Cast<PaymentMethod>()
+                    .ToArray();
+            }
 
             set
-			{
-				var strings = value.Select(e => EnumMagic.ConvertToString(e)).ToArray();
-				SetAttribute("payment_methods", strings);
-			}
+            {
+                var strings = value.Select(e => EnumMagic.ConvertToString(e)).ToArray();
+                SetAttribute("payment_methods", strings);
+            }
         }
 
         public string Color

--- a/PagarMe.Tests/PagarMeTestFixture.cs
+++ b/PagarMe.Tests/PagarMeTestFixture.cs
@@ -22,7 +22,8 @@ namespace PagarMe.Tests
                 Days = 30,
 				TrialDays = 0,
                 Amount = 1099,
-                Color = "#787878"
+                Color = "#787878",
+				PaymentMethods = new PaymentMethod[] { PaymentMethod.CreditCard }
             };
         }
 

--- a/PagarMe.Tests/PagarMeTestFixture.cs
+++ b/PagarMe.Tests/PagarMeTestFixture.cs
@@ -23,7 +23,7 @@ namespace PagarMe.Tests
 				TrialDays = 0,
                 Amount = 1099,
                 Color = "#787878",
-				PaymentMethods = new PaymentMethod[] { PaymentMethod.CreditCard }
+                PaymentMethods = new PaymentMethod[] { PaymentMethod.CreditCard }
             };
         }
 

--- a/PagarMe.Tests/SubscriptionTests.cs
+++ b/PagarMe.Tests/SubscriptionTests.cs
@@ -21,11 +21,11 @@ namespace PagarMe.Tests
 
             var subscription = new Subscription
             {
-				CardHash = GetCardHash(),
-				Customer = new Customer
-				{
-					Email = "josedasilva@pagar.me"
-				},
+                CardHash = GetCardHash(),
+                Customer = new Customer
+                {
+                    Email = "josedasilva@pagar.me"
+                },
                 Plan = plan
             };
 
@@ -34,28 +34,28 @@ namespace PagarMe.Tests
             Assert.AreEqual(subscription.Status, SubscriptionStatus.Paid);
         }
 
-		[Test]
-		public void CancelSubscription()
-		{
-			var plan = CreateTestPlan();
-			plan.Save();
+        [Test]
+        public void CancelSubscription()
+        {
+            var plan = CreateTestPlan();
+            plan.Save();
 
-			Assert.AreNotEqual(plan.Id, 0);
+            Assert.AreNotEqual(plan.Id, 0);
 
             var subscription = new Subscription
-			{
-				CardHash = GetCardHash(),
-				Customer = new Customer
-				{
-					Email = "josedasilva@pagar.me"
-				},
-				Plan = plan
-			};
+            {
+                CardHash = GetCardHash(),
+                Customer = new Customer
+                {
+                    Email = "josedasilva@pagar.me"
+                },
+                Plan = plan
+            };
 
             subscription.Save();
-			subscription.Cancel();
+            subscription.Cancel();
 
-			Assert.AreEqual(subscription.Status, SubscriptionStatus.Canceled);
-		}
+            Assert.AreEqual(subscription.Status, SubscriptionStatus.Canceled);
+        }
     }
 }


### PR DESCRIPTION
There is a bug in which, when you try to save a Plan that has PaymentMethods set, it throws an InvalidCastException. This pull request fixes it.

```c#
new Plan()
{
	Name = "Test Plan",
	Days = 30,
	TrialDays = 0,
	Amount = 1099,
	Color = "#787878",
	PaymentMethods = new PaymentMethod[] { PaymentMethod.CreditCard }
}.Save();
```