### PR TITLE
Small fixes

### DIFF
--- a/PagarMe.Shared/PaymentMethod.cs
+++ b/PagarMe.Shared/PaymentMethod.cs
@@ -33,7 +33,9 @@ namespace PagarMe
         [Base.EnumValue("credit_card")]
         CreditCard,
         [Base.EnumValue("boleto")]
-        Boleto
+        Boleto,
+	[Base.EnumValue("debit_card")]
+	DebitCard
     }
 }
 

--- a/PagarMe.Shared/SplitRule.cs
+++ b/PagarMe.Shared/SplitRule.cs
@@ -61,9 +61,9 @@ namespace PagarMe
 			set { SetAttribute("liable", value); }
 		}
 
-		public float Percentage
+		public int Percentage
 		{
-			get { return GetAttribute<float>("percentage"); }
+			get { return GetAttribute<int>("percentage"); }
 			set { SetAttribute("percentage", value); }
 		}
 

--- a/PagarMe.Shared/Transaction.cs
+++ b/PagarMe.Shared/Transaction.cs
@@ -122,9 +122,9 @@ namespace PagarMe
             set { SetAttribute("tid", value); }
         }
 
-        public string Nsu
+        public int Nsu
         {
-            get { return GetAttribute<string>("nsu"); }
+            get { return GetAttribute<int>("nsu"); }
             set { SetAttribute("nsu", value); }
         }
 


### PR DESCRIPTION
* Dado que a API não reconhece uma split rule com `percentage` com casas decimais como válida, o SDK C# deixa igualmente de aceitá-las.
* Adiciona à enum `PaymentMethod` a propriedade `DebitCard`, para transações EMV.