### PR TITLE
Change PaymentDate and OriginalPaymentDate from String to DateTime

### DIFF
--- a/PagarMe.Shared/Model/Payable.cs
+++ b/PagarMe.Shared/Model/Payable.cs
@@ -70,16 +70,16 @@ namespace PagarMe
             set { SetAttribute("recipient_id", value); }
         }
 
-        public string PaymentDate
+        public DateTime PaymentDate
         {
-            get { return GetAttribute<string>("payment_date"); }
-            set { SetAttribute("payment_date", value); }
+            get { return GetAttribute<DateTime>("payment_date"); }
+            set { SetAttribute("payment_date", Utils.ConvertToUnixTimeStamp(value)); }
         }
 
-        public string OriginalPaymentDate
+        public DateTime OriginalPaymentDate
         {
-            get { return GetAttribute<string>("original_payment_date"); }
-            set { SetAttribute("original_payment_date", value); }
+            get { return GetAttribute<DateTime>("original_payment_date"); }
+            set { SetAttribute("original_payment_date", Utils.ConvertToUnixTimeStamp(value)); }
         }
 
         public PayableType Type


### PR DESCRIPTION
If approved this PR changes type of vars: OriginalPaymentDate and PaymentDate from model class Payable.cs. 
The context of this pull request was set by a bad functioning when running Console.log on this attributes.  