### PR TITLE
Fix/split rule recipient parameter

### DIFF
--- a/PagarMe.Shared/Model/SplitRule.cs
+++ b/PagarMe.Shared/Model/SplitRule.cs
@@ -32,7 +32,6 @@ namespace PagarMe
 		public string Id {
 			get {
 				var result = GetAttribute<object> ("id");
-
 				if (result == null)
 					return null;
 				

--- a/PagarMe.Shared/Model/SplitRule.cs
+++ b/PagarMe.Shared/Model/SplitRule.cs
@@ -34,7 +34,7 @@ namespace PagarMe
 				var result = GetAttribute<object> ("id");
 				if (result == null)
 					return null;
-				
+
 				return result.ToString ();
 			}
 			set { SetAttribute ("id", value); }

--- a/PagarMe.Shared/Model/SplitRule.cs
+++ b/PagarMe.Shared/Model/SplitRule.cs
@@ -27,68 +27,59 @@ using System;
 
 namespace PagarMe
 {
-    public class SplitRule : Base.AbstractModel
-    {
-        public string Id
-        {
-            get
-            {
-                var result = GetAttribute<object>("id");
+	public class SplitRule : Base.AbstractModel
+	{
+		public string Id {
+			get {
+				var result = GetAttribute<object> ("id");
 
-                if (result == null)
-                    return null;
+				if (result == null)
+					return null;
+				
+				return result.ToString ();
+			}
+			set { SetAttribute ("id", value); }
+		}
 
-                return result.ToString();
-            }
-            set { SetAttribute("id", value); }
-        }
+		[Obsolete ("Recipient is deprecated, use acessors to RecipientId instead.")]
+		public Recipient Recipient {
+			get { return GetAttribute<Recipient> ("recipient"); }
+			set { SetAttribute ("recipient", value); }
+		}
 
-        [Obsolete("Recipient is deprecated, use acessors to RecipientId instead.")]
-        public Recipient Recipient
-        {
-            get { return GetAttribute<Recipient>("recipient"); }
-            set { SetAttribute("recipient", value); }
-        }
+		public string RecipientId {
+			get { return GetAttribute<string> ("recipient_id"); }
+			set { SetAttribute ("recipient_id", value); }
+		}
 
-        public string RecipientId
-        {
-            get { return GetAttribute<string>("recipient_id"); }
-            set { SetAttribute("recipient_id", value); }
-        }
+		public bool ChargeProcessingFee {
+			get { return GetAttribute<bool> ("charge_processing_fee"); }
+			set { SetAttribute ("charge_processing_fee", value); }
+		}
 
-        public bool ChargeProcessingFee
-        {
-            get { return GetAttribute<bool>("charge_processing_fee"); }
-            set { SetAttribute("charge_processing_fee", value); }
-        }
+		public bool Liable {
+			get { return GetAttribute<bool> ("liable"); }
+			set { SetAttribute ("liable", value); }
+		}
 
-        public bool Liable
-        {
-            get { return GetAttribute<bool>("liable"); }
-            set { SetAttribute("liable", value); }
-        }
+		public int Percentage {
+			get { return GetAttribute<int> ("percentage"); }
+			set { SetAttribute ("percentage", value); }
+		}
 
-        public int Percentage
-        {
-            get { return GetAttribute<int>("percentage"); }
-            set { SetAttribute("percentage", value); }
-        }
+		public int Amount {
+			get { return GetAttribute<int> ("amount"); }
+			set { SetAttribute ("amount", value); }
+		}
 
-        public int Amount
-        {
-            get { return GetAttribute<int>("amount"); }
-            set { SetAttribute("amount", value); }
-        }
+		public SplitRule ()
+			: this (null)
+		{
+		}
 
-        public SplitRule()
-            : this(null)
-        {
-        }
-
-        public SplitRule(PagarMeService service)
-            : base(service)
-        {
-        }
-    }
+		public SplitRule (PagarMeService service)
+			: base (service)
+		{
+		}
+	}
 }
-

--- a/PagarMe.Shared/Model/SplitRule.cs
+++ b/PagarMe.Shared/Model/SplitRule.cs
@@ -27,61 +27,68 @@ using System;
 
 namespace PagarMe
 {
-	public class SplitRule : Base.AbstractModel
-	{
-		public string Id
-		{
-			get
-			{
-				var result = GetAttribute<object>("id");
+    public class SplitRule : Base.AbstractModel
+    {
+        public string Id
+        {
+            get
+            {
+                var result = GetAttribute<object>("id");
 
-				if (result == null)
-					return null;
+                if (result == null)
+                    return null;
 
-				return result.ToString();
-			}
-			set { SetAttribute("id", value); }
-		}
+                return result.ToString();
+            }
+            set { SetAttribute("id", value); }
+        }
 
-		public Recipient Recipient
-		{
-			get { return GetAttribute<Recipient>("recipient"); }
-			set { SetAttribute("recipient", value); }
-		}
+        [Obsolete("Recipient is deprecated, use acessors to RecipientId instead.")]
+        public Recipient Recipient
+        {
+            get { return GetAttribute<Recipient>("recipient"); }
+            set { SetAttribute("recipient", value); }
+        }
 
-		public bool ChargeProcessingFee
-		{
-			get { return GetAttribute<bool>("charge_processing_fee"); }
-			set { SetAttribute("charge_processing_fee", value); }
-		}
+        public string RecipientId
+        {
+            get { return GetAttribute<string>("recipient_id"); }
+            set { SetAttribute("recipient_id", value); }
+        }
 
-		public bool Liable
-		{
-			get { return GetAttribute<bool>("liable"); }
-			set { SetAttribute("liable", value); }
-		}
+        public bool ChargeProcessingFee
+        {
+            get { return GetAttribute<bool>("charge_processing_fee"); }
+            set { SetAttribute("charge_processing_fee", value); }
+        }
 
-		public int Percentage
-		{
-			get { return GetAttribute<int>("percentage"); }
-			set { SetAttribute("percentage", value); }
-		}
+        public bool Liable
+        {
+            get { return GetAttribute<bool>("liable"); }
+            set { SetAttribute("liable", value); }
+        }
 
-		public int Amount
-		{
-			get { return GetAttribute<int>("amount"); }
-			set { SetAttribute("amount", value); }
-		}
+        public int Percentage
+        {
+            get { return GetAttribute<int>("percentage"); }
+            set { SetAttribute("percentage", value); }
+        }
 
-		public SplitRule()
-			: this(null)
-		{
-		}
+        public int Amount
+        {
+            get { return GetAttribute<int>("amount"); }
+            set { SetAttribute("amount", value); }
+        }
 
-		public SplitRule(PagarMeService service)
-			: base(service)
-		{
-		}
-	}
+        public SplitRule()
+            : this(null)
+        {
+        }
+
+        public SplitRule(PagarMeService service)
+            : base(service)
+        {
+        }
+    }
 }
 


### PR DESCRIPTION
This PR deprecates Recipient parameter to avoid NullException on Transaction with Split Rules information. 