### PR TITLE
tls: fix to use 1.2 for requests

### DIFF
--- a/PagarMe.Shared/PagarMe.Shared.projitems
+++ b/PagarMe.Shared/PagarMe.Shared.projitems
@@ -67,6 +67,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Base\EnumMagic.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Base\EnumValueAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Base\SerializationType.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TLS.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Event.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Enumeration\CustomerType.cs" />

--- a/PagarMe.Shared/TLS.cs
+++ b/PagarMe.Shared/TLS.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace PagarMe
+{
+    public class TLS
+    {
+        private TLS(){ }
+        public static TLS Instance = new TLS();
+
+        #if !PCL
+        private SecurityProtocolType @default;
+        #endif
+        
+        #if NET40
+        private const SecurityProtocolType tls12 = (SecurityProtocolType) 3072;
+        #elif !PCL
+        private const SecurityProtocolType tls12 = SecurityProtocolType.Tls12;
+        #endif
+
+        /// <summary>
+        /// Changes the default protocol to TLS 1.2
+        /// to run the request that needs this protocol
+        /// then return to previous configuration
+        /// </summary>
+        public async Task<T> UseTLS12IfAvailable<T>(Func<Task<T>> requestCode)
+        {
+            goToTLS12();
+            var result = await requestCode();
+            restoreDefaultTLS();
+            return result;
+        }
+
+        /// <summary>
+        /// Changes the default protocol to TLS 1.2
+        /// to run the request that needs this protocol
+        /// then return to previous configuration
+        /// </summary>
+        public T UseTLS12IfAvailable<T>(Func<T> requestCode)
+        {
+            goToTLS12();
+            var result = requestCode();
+            restoreDefaultTLS();
+            return result;
+        }
+
+        private void goToTLS12()
+        {
+            #if !PCL
+            @default = ServicePointManager.SecurityProtocol;
+            ServicePointManager.SecurityProtocol = tls12;
+            #endif
+        }
+
+        private void restoreDefaultTLS()
+        {
+            #if !PCL
+            ServicePointManager.SecurityProtocol = @default;
+            #endif
+        }
+    }
+}


### PR DESCRIPTION
Na library portable não foi colocado o TLS 1.2. Estranhei os diversos `#if`s, o fato de nunca ter visto subir versão nova da portable, nem sabia que existia.

Fui olhar no Nuget, não é atualizada fez 2 anos semana passada. A gente tá de fato mantendo essa library? Porque quem estiver usando ela deve cair quando virarmos o TLS.

PS: era pra master do repo estar desprotegida de merge sem approve?