### PR TITLE
Fix GetAttribute to handle null responses

### DIFF
--- a/PagarMe.Shared/Base/AbstractModel.cs
+++ b/PagarMe.Shared/Base/AbstractModel.cs
@@ -340,8 +340,13 @@ namespace PagarMe.Base
             if (!_dirtyKeys.TryGetValue(name, out result))
             if (!_keys.TryGetValue(name, out result))
                 return default(T);
-
-            return CastAttribute<T>(result);
+            try
+            { 
+                return CastAttribute<T>(result);
+            }
+            catch (NullReferenceException) {
+                return default(T);
+            }
         }
 
         protected void SetAttribute(string name, object value, bool dirty = true)


### PR DESCRIPTION
All methods that used the GetAttribute would fail when receiving a null parameter.
This fix allows them give a treatable error.