### PR TITLE
Fix to allow the SubscriptionId to handle a null value

### DIFF
--- a/PagarMe.Shared/Model/Transaction.cs
+++ b/PagarMe.Shared/Model/Transaction.cs
@@ -48,9 +48,20 @@ namespace PagarMe
             set { SetAttribute("subscription", value); }
         }
 
-        public int SubscriptionId
+        public int? SubscriptionId
         {
-            get { return GetAttribute<int>("subscription_id") ; }
+               get
+            {
+                try
+                {
+                    return GetAttribute<int>("subscription_id");
+
+                }
+                catch (Exception)
+                {
+                    return null;
+                }
+            }
         }
 
         public Card Card


### PR DESCRIPTION
Due to the change in the GetAttribute method, the SubscriptionId was unable to accept a null value.
This change makes said exception return "null".  