### PR TITLE
Fix refund with split

### DIFF
--- a/PagarMe.Shared/Model/Transaction.cs
+++ b/PagarMe.Shared/Model/Transaction.cs
@@ -457,7 +457,7 @@ namespace PagarMe
                 request.Query = BuildQueryForKeys("bank_account", bank.ToDictionary(Base.SerializationType.Plain));
             }
 
-            request.Body = JsonConvert.SerializeObject(split_rules.Select(s => s.ToDictionary(SerializationType.Plain)).ToList());
+            request.Body = "{\"split_rules\":" + JsonConvert.SerializeObject(split_rules.Select(s => s.ToDictionary(SerializationType.Plain)).ToList()) + "}";
 
             request.Query.Add(new Tuple<string, string>("amount", amount.Value.ToString()));
 

--- a/PagarMe.Tests/PayableTest.cs
+++ b/PagarMe.Tests/PayableTest.cs
@@ -19,6 +19,8 @@ namespace PagarMe.Tests
             transaction.Status = TransactionStatus.Paid;
             transaction.Save();
 
+            System.Threading.Thread.Sleep(10000);
+
             Payable payable = transaction.Payables.FindAll(new Payable()).First();
             Payable payableReturned = PagarMeService.GetDefaultService().Payables.Find(payable.Id);
 

--- a/PagarMe.Tests/RecipientTests.cs
+++ b/PagarMe.Tests/RecipientTests.cs
@@ -54,6 +54,9 @@ namespace PagarMe.Tests
             transaction.Save();
             transaction.Status = TransactionStatus.Paid;
             transaction.Save();
+
+            System.Threading.Thread.Sleep(10000);
+
             BalanceOperation[] operation = recipient.Balance.Operations.FindAll(new BalanceOperation()).ToArray();
 
             Assert.IsNotNull(operation.First().MovementPayable);

--- a/PagarMe.Tests/SubscriptionTests.cs
+++ b/PagarMe.Tests/SubscriptionTests.cs
@@ -192,6 +192,8 @@ namespace PagarMe.Tests
 
 			Assert.AreEqual(subscription.Status, SubscriptionStatus.Paid);
 
+			System.Threading.Thread.Sleep(10000);
+
 			List<Payable> subscriptionPayables = subscription.CurrentTransaction.Payables.FindAll(new Payable()).ToList();
 			List<Payable> firstRecipientPayable = subscriptionPayables.Where(x => x.RecipientId == recipient1.Id).ToList();
 			List<Payable> secondRecipientPayable = subscriptionPayables.Where(x => x.RecipientId == recipient2.Id).ToList();

--- a/PagarMe.Tests/TransactionTests.cs
+++ b/PagarMe.Tests/TransactionTests.cs
@@ -170,6 +170,8 @@ namespace PagarMe.Tests
             transaction.Status = TransactionStatus.Paid;
             transaction.Save();
 
+            System.Threading.Thread.Sleep(10000);
+
             Payable payable = transaction.Payables.FindAll(new Payable()).First();
             Assert.IsTrue(payable.Amount.Equals(transaction.Amount));
             Assert.IsTrue(payable.Status.Equals(PayableStatus.Paid));
@@ -327,21 +329,22 @@ namespace PagarMe.Tests
             var splitRules = new SplitRule[]{
                 new SplitRule(){
                     Id = transaction.SplitRules[0].Id,
-                    Amount = 200,
+                    Amount = 300,
                     RecipientId = transaction.SplitRules[0].RecipientId,
                     ChargeProcessingFee = true
                 },
                 new SplitRule(){
                     Id = transaction.SplitRules[1].Id,
-                    Amount = 200,
+                    Amount = 100,
                     RecipientId = transaction.SplitRules[1].RecipientId,
                     ChargeProcessingFee = true
                 }
             };
             transaction.RefundWithSplit(400,splitRules);
+            System.Threading.Thread.Sleep(10000);
             List<Payable> payables = transaction.Payables.FindAll(new Payable()).ToList();
-            Assert.AreEqual(payables.ElementAt(0).Amount,-200);
-            Assert.AreEqual(payables.ElementAt(1).Amount, -200);
+            Assert.AreEqual(payables.ElementAt(0).Amount,-300);
+            Assert.AreEqual(payables.ElementAt(1).Amount, -100);
         }
 
         [Test]
@@ -371,13 +374,13 @@ namespace PagarMe.Tests
             var splitRules = new SplitRule[]{
                 new SplitRule(){
                     Id = transaction.SplitRules[0].Id,
-                    Amount = 200,
+                    Amount = 300,
                     RecipientId = transaction.SplitRules[0].RecipientId,
                     ChargeProcessingFee = true
                 },
                 new SplitRule(){
                     Id = transaction.SplitRules[1].Id,
-                    Amount = 200,
+                    Amount = 100,
                     RecipientId = transaction.SplitRules[1].RecipientId,
                     ChargeProcessingFee = true
                 }
@@ -385,9 +388,10 @@ namespace PagarMe.Tests
             BankAccount ba = CreateTestBankAccount();
             ba.Save();
             transaction.RefundWithSplit(400, splitRules,ba);
+            System.Threading.Thread.Sleep(10000);
             List<Payable> payables = transaction.Payables.FindAll(new Payable()).ToList();
-            Assert.AreEqual(payables.ElementAt(0).Amount, -200);
-            Assert.AreEqual(payables.ElementAt(1).Amount, -200);
+            Assert.AreEqual(payables.ElementAt(0).Amount, -300);
+            Assert.AreEqual(payables.ElementAt(1).Amount, -100);
             Assert.AreEqual(transaction.Status,TransactionStatus.PendingRefund);
         }
     }


### PR DESCRIPTION
Corrige o método de estorno com split, que atualmente envia as _split rules_ diretamente no body da requisição, sem o objeto _split_rules_. 

Os testes também foram ajustados, pois atualmente é criada uma transação com split de 50% para cada recebedor e é estornado da mesma forma (metade do valor para cada), dando margem para falsos positivos. Além disso, adicionei um sleep nos testes com split rules antes da verificação dos payables, já que agora temos um delay de alguns segundos devido ao Atlas.